### PR TITLE
indexHint 与Builder内类型统一

### DIFF
--- a/src/Query/SqlServerBuilder.php
+++ b/src/Query/SqlServerBuilder.php
@@ -35,7 +35,7 @@ class SqlServerBuilder extends Builder
     /**
      * The index hint for the query.
      */
-    public IndexHint $indexHint;
+    public $indexHint;
 
     /**
      * Add an "order by" clause to the query.


### PR DESCRIPTION
报错内容  Type of Hyperf\Database\Sqlsrv\Query\SqlServerBuilder::$indexHint must not be defined (as in class Hyperf\Database\Query\Builder) in /data/project/hyperf/vendor/hyperf/database-sqlserver-incubator/src/Query/SqlServerBuilder.php on line 25